### PR TITLE
Add CC14 resources post

### DIFF
--- a/_posts/2026-02-10-cc14-resources.md
+++ b/_posts/2026-02-10-cc14-resources.md
@@ -1,0 +1,29 @@
+---
+layout: post
+title: "CC14 Resources: schematics, STLs, gerbers, and more"
+---
+
+If you’re looking for the **CactusCon 14 badge (CC14)** files—this is the one link you want.
+
+## CC14 resource hub
+
+All the design files live in the GitHub repo:
+
+- https://github.com/BadgePiratesLLC/CactusCon14
+
+### What’s in there
+
+- **Schematics (PDF):** `Schematics/CC14.pdf`
+- **Interactive BOM:** `bom/ibom.html`
+- **KiCad project files:** `CAD/`
+- **Gerbers + drill files:** `CAD/gerbers/` (plus `CAD/gerbers/Outer/`)
+- **3D prints (STL/3MF):** `STL/`
+- **Art assets:** `Art/`
+
+## Quick tip
+
+If you’re fabbing boards, start with the gerber ZIPs (or zip the `.gbr` + `.drl` yourself) and use the iBOM for placement.
+
+If you build/print one, tag us—seeing these out in the wild rules.
+
+— Kevin (@fg)


### PR DESCRIPTION
Adds a short blog post pointing readers to the CC14 resource hub (schematics/STLs/gerbers/iBOM) in the CactusCon14 repo.